### PR TITLE
Fix concat bug in browser

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -95,7 +95,7 @@ function concat (buffers, totalLength) {
   let offset = 0
   for (const buffer of buffers) {
     if (offset + buffer.length > result.length) {
-      const sub = buffer.slice(0, result.length - offset)
+      const sub = buffer.subarray(0, result.length - offset)
       result.set(sub, offset)
       return result
     }

--- a/browser.js
+++ b/browser.js
@@ -94,13 +94,13 @@ function concat (buffers, totalLength) {
 
   let offset = 0
   for (const buffer of buffers) {
-    if (offset + buffer.length > result.length) {
-      const sub = buffer.subarray(0, result.length - offset)
+    if (offset + buffer.byteLength > result.byteLength) {
+      const sub = buffer.subarray(0, result.byteLength - offset)
       result.set(sub, offset)
       return result
     }
     result.set(buffer, offset)
-    offset += buffer.length
+    offset += buffer.byteLength
   }
 
   return result

--- a/browser.js
+++ b/browser.js
@@ -92,13 +92,16 @@ function concat (buffers, totalLength) {
 
   const result = new Uint8Array(totalLength)
 
-  buffers.reduce(
-    (offset, buffer) => {
-      result.set(buffer, offset)
-      return offset + buffer.byteLength
-    },
-    0
-  )
+  let offset = 0
+  for (const buffer of buffers) {
+    if (offset + buffer.length > result.length) {
+      const sub = buffer.slice(0, result.length - offset)
+      result.set(sub, offset)
+      return result
+    }
+    result.set(buffer, offset)
+    offset += buffer.length
+  }
 
   return result
 }

--- a/test/browser.mjs
+++ b/test/browser.mjs
@@ -58,8 +58,7 @@ test('concat with length', (t) => {
   t.alike(b.concat([b.from([1, 2, 3]), b.from([4, 5, 6])], 5), b.from([1, 2, 3, 4, 5]))
   t.alike(b.concat([b.from([1, 2, 3]), b.from([4, 5, 6], [7, 8, 9])], 5), b.from([1, 2, 3, 4, 5]))
   t.alike(b.concat([b.from([1, 2, 3]), b.from([4, 5, 6])], 6), b.from([1, 2, 3, 4, 5, 6]))
-  const initValue = 0
-  t.alike(b.concat([b.from([1, 2, 3]), b.from([4, 5, 6])], 7), b.from([1, 2, 3, 4, 5, 6, initValue]))
+  t.alike(b.concat([b.from([1, 2, 3]), b.from([4, 5, 6])], 7), b.from([1, 2, 3, 4, 5, 6, 0]))
 })
 
 test('copy', (t) => {

--- a/test/browser.mjs
+++ b/test/browser.mjs
@@ -54,6 +54,10 @@ test('concat', (t) => {
   t.alike(b.concat([b.from([1, 2, 3]), b.from([4, 5, 6])]), b.from([1, 2, 3, 4, 5, 6]))
 })
 
+test('concat with length', (t) => {
+  t.alike(b.concat([b.from([1, 2, 3]), b.from([4, 5, 6])], 5), b.from([1, 2, 3, 4, 5]))
+})
+
 test('copy', (t) => {
   const x = b.from([1, 2, 3])
   const y = b.alloc(3)

--- a/test/browser.mjs
+++ b/test/browser.mjs
@@ -56,6 +56,10 @@ test('concat', (t) => {
 
 test('concat with length', (t) => {
   t.alike(b.concat([b.from([1, 2, 3]), b.from([4, 5, 6])], 5), b.from([1, 2, 3, 4, 5]))
+  t.alike(b.concat([b.from([1, 2, 3]), b.from([4, 5, 6], [7, 8, 9])], 5), b.from([1, 2, 3, 4, 5]))
+  t.alike(b.concat([b.from([1, 2, 3]), b.from([4, 5, 6])], 6), b.from([1, 2, 3, 4, 5, 6]))
+  const initValue = 0
+  t.alike(b.concat([b.from([1, 2, 3]), b.from([4, 5, 6])], 7), b.from([1, 2, 3, 4, 5, 6, initValue]))
 })
 
 test('copy', (t) => {


### PR DESCRIPTION
`concat` fails in the browser if specifying the optional `totalLength` arg

The current alg tries to copy more entries to the utf-8 array than there is space available, so it throws. I added a simple algorithm which I think does work, but it can probably be improved